### PR TITLE
remove unnecessary logging

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,6 @@
 import * as vscode from 'vscode';
 
 export function activate(context: vscode.ExtensionContext) {
-    console.log('Congratulations, your extension "vscode-erase-formatter" is now active!');
     
     // console.log('bs =', count(vscode.window.activeTextEditor.document.getText()));
 


### PR DESCRIPTION
This `console.log` is unnecessary, and even confusing, because this extension is not named "vscode-erase-formatter". So it'd be better to delete it.